### PR TITLE
Fix afg sin fn

### DIFF
--- a/Instruments/afg.py
+++ b/Instruments/afg.py
@@ -205,7 +205,7 @@ class AFG (SerialInstrument):
             unit_chosen = thisunit
             f_chosen = thisf
         # }}}
-        cmd = 'SOUR%d:APPL:SIN %0.3f%s,%f,0'%(ch,f/f_chosen,unit_chosen,V)
+        cmd = 'SOUR%d:APPL:SIN %0.3f%s,1,0'%(ch,f/f_chosen,unit_chosen)
         print(cmd)
         self.write(cmd)
         

--- a/Instruments/afg.py
+++ b/Instruments/afg.py
@@ -205,7 +205,7 @@ class AFG (SerialInstrument):
             unit_chosen = thisunit
             f_chosen = thisf
         # }}}
-        cmd = 'SOUR%d:APPL:SIN %0.3f%s,1,0'%(ch,f/f_chosen,unit_chosen)
+        cmd = 'SOUR%d:APPL:SIN %0.3f%s,%f,0'%(ch,f/f_chosen,unit_chosen,V)
         print(cmd)
         self.write(cmd)
         


### PR DESCRIPTION
When testing AFG outputting sine wave noticed the voltage I told it to output wasn't being output, the function has a V kwarg but in the actual command to the AFG just sent 1 Vpp, I changed this so now it uses the V kwarg instead.